### PR TITLE
Make app.silence() iterate over app.log methods to silence.

### DIFF
--- a/cantina.js
+++ b/cantina.js
@@ -120,9 +120,12 @@ app.destroy = function (callback) {
  * 'Silence' the app.
  */
 app.silence = function () {
+  var noops = Object.keys(app.log).filter(function (prop) {
+    return Object.hasOwnProperty.call(app.log, prop) && typeof app.log[prop] === 'function';
+  });
   app.log = function () {};
-  app.log.error = app.log;
-  app.log.info = app.log;
-  app.log.warn = app.log;
+  noops.forEach(function (noop) {
+    app.log[noop] = app.log;
+  });
 };
 

--- a/cantina.js
+++ b/cantina.js
@@ -121,7 +121,7 @@ app.destroy = function (callback) {
  */
 app.silence = function () {
   var noops = Object.keys(app.log).filter(function (prop) {
-    return Object.hasOwnProperty.call(app.log, prop) && typeof app.log[prop] === 'function';
+    return typeof app.log[prop] === 'function';
   });
   app.log = function () {};
   noops.forEach(function (noop) {


### PR DESCRIPTION
As discussed on IM with @cpsubrian. This unbreaks the interaction with app.log.debug, exposed by cantina-log.
